### PR TITLE
Reset header font widths

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -25,6 +25,7 @@ time, mark, audio, video {
     font-size:100%;
     vertical-align:baseline;
     background:transparent;
+    font-weight:inherit;
 }
 
 body {


### PR DESCRIPTION
Without this line, `h1` to `h6` tags still have the browser stylesheet definitions of `font-weight: bold` which can trip you up, particularly if you're using a webfont where your "bold" is actually `font-weight: 600` (not 700). That's how I hit this, anyway.
